### PR TITLE
Inverted inital relay logic

### DIFF
--- a/install_scripts/setup.sh
+++ b/install_scripts/setup.sh
@@ -300,8 +300,8 @@ else
 input_pins=13, 19, 16, 26, 20, 21
 relay_pins=5, 6, 12
 # outputs
-relays_start_config=True,True,True
-relays_active_high=False,False,False" | sudo tee -a generated.cfg
+relays_start_config=False,False,False
+relays_active_high=True,True,True" | sudo tee -a generated.cfg
 fi
 
 echo "input_pull_up=False,False,False,False,False,False


### PR DESCRIPTION
andinopy/andinopy/base_devices/andinoio.py contains
```
if bool(state):
            self.outRel[relays_nr].on()
        else:
            self.outRel[relays_nr].off()
```
However inital configuration turns off relay when off() is called and vice versa.
 