### PR TITLE
stop blinking display on setting text

### DIFF
--- a/andinopy/base_devices/andino_io_oled.py
+++ b/andinopy/base_devices/andino_io_oled.py
@@ -97,7 +97,6 @@ class andino_io_oled:
         Displays the text set in self.text
         """
         if sys.platform == "linux":
-            self.display.fill(0)
             self.display.show()
         my_image = Image.new('1', (self.WIDTH, self.HEIGHT))
 


### PR DESCRIPTION
calling fill(0) every time causes the display to clear before displaying new text. The display seems to blink when watich. This is annoying. A simple test turns out, that calling fill(0) is not necessary and the blinking stops.